### PR TITLE
Make mongo & mongo-express safer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,5 @@ config/config.yml
 config/config.env
 
 docker-compose.dev.yml
+
+mongodb/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: mongo:latest
     restart: always
     ports:
-      - ${MONGODB_PORT:-27017}:${MONGODB_PORT:-27017}
+      - 127.0.0.1:${MONGODB_PORT:-27017}:${MONGODB_PORT:-27017}
     volumes:
       - ${MONGODB_PATH:-./mongodb}:/data/db
     # TODO: add auth
@@ -26,7 +26,7 @@ services:
     image: mongo-express:latest
     restart: always
     ports:
-      - ${MONGO_EXPRESS_PORT:-8081}:${MONGO_EXPRESS_PORT:-8081}
+      - 127.0.0.1:${MONGO_EXPRESS_PORT:-8081}:${MONGO_EXPRESS_PORT:-8081}
     environment:
       - ME_CONFIG_MONGODB_SERVER=mongo
       - ME_CONFIG_MONGODB_PORT=${MONGODB_PORT:-27017}


### PR DESCRIPTION
Listen on localhost only.
Can still be accessed via ssh tunnel
Example: ssh -L8081:127.0.0.1:8081 <user@host>
